### PR TITLE
active error_log

### DIFF
--- a/backend/userbackend.php
+++ b/backend/userbackend.php
@@ -46,6 +46,7 @@ class UserBackend extends \OC_User_Backend { //implements \OC_User_Interface {
 
 		$this->autoCreateUser = false;
 		$autoCreateUser = $config->getValue('user_servervars2', 'auto_create_user','false');
+		error_log('servervars2 - backend/userbackend.php autoCreateUser ' . $autoCreateUser);
 		if ($autoCreateUser !== 'false') {
 				$this->autoCreateUser = true;
 		}

--- a/service/proxyuserandgroupservice.php
+++ b/service/proxyuserandgroupservice.php
@@ -58,6 +58,7 @@ class ProxyUserAndGroupService implements UserAndGroupService {
 
 
 	public function provisionUser($uid, $tokens) {
+			error_log('servervars2 - service/proxyuserandgroupservice.php provisionUser uid ' . $uid);
 			if ( $this->isAutoCreateUser() ) {
 				$justCreatedUser = $this->createUser($uid);
 			}
@@ -129,23 +130,23 @@ class ProxyUserAndGroupService implements UserAndGroupService {
 		$uid = $user->getUID();
 
 		if (empty($groupsArray) && !empty($defaultGroups)) {
-            $groupsArray = $defaultGroups;
-        }
+            		$groupsArray = $defaultGroups;
+        	}
 
-        $naming = $this->groupNamingService;
+        	$naming = $this->groupNamingService;
 
-        $groupNames = $this->getGroupNames($groupsArray, $naming);
+        	$groupNames = $this->getGroupNames($groupsArray, $naming);
 
 
 		$rawOldGroupIds = $this->groupManager->getUserGroupIds( $user );
-        $oldGroupNames = $this->getOldGroupNames($rawOldGroupIds, $naming);
+        	$oldGroupNames = $this->getOldGroupNames($rawOldGroupIds, $naming);
 
 
-    	$toAddGrps = $this->getGroupNamesToAdd($groupNames, $oldGroupNames);
-    	$toRemGrps = $this->getGroupNamesToRemove($groupNames, $oldGroupNames);
+    		$toAddGrps = $this->getGroupNamesToAdd($groupNames, $oldGroupNames);
+    		$toRemGrps = $this->getGroupNamesToRemove($groupNames, $oldGroupNames);
 
-    	$this->addToGroup($user, $toAddGrps);
-    	$this->removeFromGroup($user, $toRemGrps);
+    		$this->addToGroup($user, $toAddGrps);
+    		$this->removeFromGroup($user, $toRemGrps);
 
 	}
 


### PR DESCRIPTION
bonjour,
dans les logs, autoCreateUser vaut false : 
[Thu Jun 30 09:22:27.475383 2016] [:error] [pid 28425] [client 172.20.74.124:38020] servervars2 - backend/userbackend.php autoCreateUser false
bizarre, non ?
Ernerst.
